### PR TITLE
Apply pale orange background to frames

### DIFF
--- a/K3_Quote_Tool_Final_Integrated.py
+++ b/K3_Quote_Tool_Final_Integrated.py
@@ -175,6 +175,7 @@ root.configure(bg="#fff0e6")
 style = ttk.Style()
 style.configure("TLabel", background="#fff0e6", font=("Arial", 10))
 style.configure("TButton", font=("Arial", 10))
+style.configure("TFrame", background="#fff0e6")
 
 frame_top = ttk.Frame(root, padding=10)
 frame_top.pack(fill="x")


### PR DESCRIPTION
## Summary
- apply the pale orange style to `TFrame`

## Testing
- `python3 K3_Quote_Tool_Final_Integrated.py` *(fails: No module named `reportlab`)*

------
https://chatgpt.com/codex/tasks/task_e_68450f37153883248eeb7c44a4d0bf33